### PR TITLE
[xcvrd] Remove the extra argument that is causing the xcvrd crash

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -8,7 +8,6 @@
 try:
     import ast
     import copy
-    import functools
     import json
     import multiprocessing
     import os
@@ -1794,9 +1793,8 @@ class SfpStateUpdateTask(object):
         timeout = RETRY_PERIOD_FOR_SYSTEM_READY_MSECS
         state = STATE_INIT
         sel, asic_context = port_mapping.subscribe_port_config_change(self.namespaces)
-        port_change_event_handler = functools.partial(self.on_port_config_change, stopping_event)
         while not stopping_event.is_set():
-            port_mapping.handle_port_config_change(sel, asic_context, stopping_event, self.port_mapping, helper_logger, port_change_event_handler)
+            port_mapping.handle_port_config_change(sel, asic_context, stopping_event, self.port_mapping, helper_logger, self.on_port_config_change)
 
             # Retry those logical ports whose EEPROM reading failed or timeout when the SFP is inserted
             self.retry_eeprom_reading()


### PR DESCRIPTION
Signed-off-by: Vivek Reddy <vkarri@nvidia.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Fixed SfpStateUpdateTask to not crash during port_cfg dynamic add/del event

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

During port breakout, the subprocess invoked by parent xcvrd is crashing indicated by the following log:

```
Nov 24 15:40:03.572897 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd Process Process-1:
Nov 24 15:40:03.577327 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd Traceback (most recent call last):
Nov 24 15:40:03.578223 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd   File "/usr/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
Nov 24 15:40:03.578478 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd     self.run()
Nov 24 15:40:03.579059 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd   File "/usr/lib/python3.9/multiprocessing/process.py", line 108, in run
Nov 24 15:40:03.579296 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd     self._target(*self._args, **self._kwargs)
Nov 24 15:40:03.580306 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1799, in task_worker
Nov 24 15:40:03.580633 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd     port_mapping.handle_port_config_change(sel, asic_context, stopping_event, self.port_mapping, helper_logger, port_change_event_handler)
Nov 24 15:40:03.581228 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd_utilities/port_mapping.py", line 224, in handle_port_config_change
Nov 24 15:40:03.581556 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd     read_port_config_change(asic_context, port_mapping, logger, port_change_event_handler)
Nov 24 15:40:03.581842 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd   File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd_utilities/port_mapping.py", line 261, in read_port_config_change
Nov 24 15:40:03.582121 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd     port_change_event_handler(port_change_event)
Nov 24 15:40:03.582402 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd TypeError: on_port_config_change() takes 2 positional arguments but 3 were given
Nov 24 15:40:03.587293 qa-eth-vt02-3-2700a0 INFO pmon#supervisord: xcvrd []
```

on_port_config_change only need one argument. It doesn't require the stopping_event arg and this removed it

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Apply breakout and check if the subprocess is not crashing

#### Additional Information (Optional)
